### PR TITLE
Add gitleaks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,9 @@ repos:
       hooks:
         - id: bandit
           args: ["-x", "./venv"]
+    - repo: https://github.com/gitleaks/gitleaks
+      rev: v8.30.1
+      hooks:
+        - id: gitleaks
 
 # Optional: create a pyproject.toml for tool configuration


### PR DESCRIPTION
## Summary
- Add [gitleaks](https://github.com/gitleaks/gitleaks) via `.pre-commit-config.yaml` (`v8.30.1`) so secrets are caught locally before push
- Complements GitHub secret scanning / push protection (defense in depth)

## Test plan
- [ ] `pip install pre-commit` (or equivalent) if needed
- [ ] `pre-commit install`
- [ ] `pre-commit run gitleaks --all-files`
- [ ] Optional: confirm hook blocks a staged fake AWS/GitHub token


Made with [Cursor](https://cursor.com)