### PR TITLE
chore(ci): bump Actions to Node 24-capable majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Sync deps


### PR DESCRIPTION
## Summary
- Bump first-party GitHub Actions still on the Node 20 *action runtime* to Node-24-capable majors (`checkout`/`setup-node`/`cache`/`upload-artifact`/`download-artifact` → v5+, `setup-python` → v6+).
- Does **not** change job `node-version` / language toolchains.

## Test plan
- [ ] CI green on this PR
- [ ] No \"Node.js 20 is deprecated\" annotation on workflow runs


Made with [Cursor](https://cursor.com)